### PR TITLE
Check if "body" on "response" is actually defined before accessing it

### DIFF
--- a/packages/helpers/classes/response-error.js
+++ b/packages/helpers/classes/response-error.js
@@ -42,7 +42,7 @@ class ResponseError extends Error {
   toString() {
     const {body} = this.response;
     let err = chalk.red(`${this.message} (${this.code})`);
-    if (Array.isArray(body.errors)) {
+    if (body && Array.isArray(body.errors)) {
       body.errors.forEach(error => {
         const message = chalk.yellow(error.message);
         const field = chalk.grey(error.field);


### PR DESCRIPTION
Catched this error when testing with a dummy API key.
```
TypeError: Cannot read property 'errors' of undefined
    at ResponseError.toString (.../node_modules/@sendgrid/helpers/classes/response-error.js:45:27)
    at parseStackAndMessage (.../node_modules/bluebird/js/release/debuggability.js:574:25)
    at CapturedTrace.attachExtraTrace (.../node_modules/bluebird/js/release/debuggability.js:778:18)
```
After adding the simple check `if (body && Array.isArray(body.errors))` the "Unauthorized (401)" error is properly returned as promise rejection.